### PR TITLE
feat: group Biome and Wrangler updates across npm and GitHub Actions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,6 +34,18 @@
       "groupName": "All patch and minor dev dependencies",
       "groupSlug": "all-patch-minor-dev-deps",
       "matchPackageNames": ["*"]
+    },
+    {
+      "groupName": "Biome updates",
+      "groupSlug": "biome",
+      "matchPackageNames": ["@biomejs/biome"],
+      "matchDepNames": ["biomejs/biome"]
+    },
+    {
+      "groupName": "Wrangler updates",
+      "groupSlug": "wrangler",
+      "matchPackageNames": ["wrangler"],
+      "matchDepNames": ["wrangler"]
     }
   ]
 }


### PR DESCRIPTION
Configure Renovate to group npm packages and GitHub Actions versions together:
- Biome: @biomejs/biome (npm) + biomejs/biome (GitHub Actions)
- Wrangler: wrangler (npm) + wrangler (GitHub Actions)

This ensures version consistency between package dependencies and CI/CD workflows.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
