### PR TITLE
fix: add matchDatasources to group Biome updates across npm and GitHub releases

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -38,12 +38,14 @@
     {
       "groupName": "Biome updates",
       "groupSlug": "biome",
+      "matchDatasources": ["npm", "github-releases"],
       "matchPackageNames": ["@biomejs/biome"],
       "matchDepNames": ["biomejs/biome"]
     },
     {
       "groupName": "Wrangler updates",
       "groupSlug": "wrangler",
+      "matchDatasources": ["npm"],
       "matchPackageNames": ["wrangler"],
       "matchDepNames": ["wrangler"]
     }


### PR DESCRIPTION
Add explicit datasource matching for Biome package rule to ensure
@biomejs/biome (npm) and biomejs/biome (github-releases) are grouped together.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
