### PR TITLE
Fix typo: Rull Request -> Pull Request in monthly reports

### DIFF
--- a/src/articles/2025-07-31_monthly-report-2507.md
+++ b/src/articles/2025-07-31_monthly-report-2507.md
@@ -19,7 +19,7 @@ ogp:
 
 ## GitHub
 
-### Rull Request
+### Pull Request
 
 - **merged** [Add comprehensive testing and CI infrastructure · Pull Request #2 · sugarshin/.claude-code-slash-commands](https://github.com/sugarshin/.claude-code-slash-commands/pull/2)
   - Merged at: 2025-07-09T11:05:22Z

--- a/src/articles/2026-03-31_monthly-report-2603.md
+++ b/src/articles/2026-03-31_monthly-report-2603.md
@@ -27,7 +27,7 @@ ogp:
   - Terraform provider to manage LIFF resources
   - Created at: 2026-03-15T06:22:03Z
 
-### Rull Request
+### Pull Request
 
 - [fix: resolve lint errors and simplify CI trigger · Pull Request #3 · sugarshin/terraform-provider-liff](https://github.com/sugarshin/terraform-provider-liff/pull/3)
   - Created at: 2026-03-15T11:40:10Z

--- a/src/articles/2026-04-30_monthly-report-2604.md
+++ b/src/articles/2026-04-30_monthly-report-2604.md
@@ -26,7 +26,7 @@ ogp:
 - [sugarshin/seam](https://github.com/sugarshin/seam)
   - Created at: 2026-04-26T06:58:26Z
 
-### Rull Request
+### Pull Request
 
 - [feat: automate IPA release for SideStore + fix test CI · Pull Request #7 · sugarshin/seam](https://github.com/sugarshin/seam/pull/7)
   - Created at: 2026-04-27T02:43:32Z


### PR DESCRIPTION
## Summary

- 月次レポート記事の見出し `### Rull Request` を `### Pull Request` に修正
- 対象: `2025-07`, `2026-03`, `2026-04` の monthly report 3 件

## Test plan

- [x] `grep -rn "Rull" src/` で残存 typo がないことを確認
- [ ] ビルド/プレビューで見出しが正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)