### PR TITLE
Fix invalid Renovate matchPackageNames configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,7 +25,7 @@
       "matchDepTypes": ["dependencies"],
       "groupName": "All patch dependencies excluded \"typescript\"",
       "groupSlug": "all-patch-deps-excluded-typescript",
-      "matchPackageNames": ["*", "!typescript"]
+      "matchPackageNames": ["!typescript"]
     },
     {
       "matchDatasources": ["npm"],


### PR DESCRIPTION
## 概要

Renovate 設定ファイル `.github/renovate.json` の無効な設定を修正します。

## 問題

`packageRules[0].matchPackageNames` が `["*", "!typescript"]` となっており、Renovate が以下のエラーを出していました:

> packageRules[0].matchPackageNames: Your input contains * or ** along with other patterns. Please remove them, as * or ** matches all patterns.

`*`（全マッチ）は他のパターンと併用できません。

## 対応

`*` を削除し `["!typescript"]` のみに変更しました。負の除外パターンのみを指定した場合、Renovate は暗黙的に「全パッケージから除外分を引いたもの」＝「typescript 以外のすべて」と解釈するため、元の意図（typescript を除く全 patch 更新をグループ化）は維持されます。

`renovate-config-validator` で検証済みです。

Fixes #2350

🤖 Generated with [Claude Code](https://claude.com/claude-code)