### PR TITLE
Add prev/next article navigation to article pages

### DIFF
--- a/src/app/[...slug]/page.tsx
+++ b/src/app/[...slug]/page.tsx
@@ -1,9 +1,14 @@
 import type { Metadata, ResolvingMetadata } from 'next';
 import ArticleMeta, { ArticleMetaData } from '~/components/ArticleMeta';
+import ArticleNav from '~/components/ArticleNav';
 import Markdown from '~/components/Markdown';
 import SocialShare from '~/components/SocialShare';
 import TwitterWidget from '~/components/TwitterWidget';
-import { getArticleFileNames, readArticleFile } from '~/libs/article';
+import {
+  getAdjacentArticles,
+  getArticleFileNames,
+  readArticleFile,
+} from '~/libs/article';
 import { truncateArticleByLength } from '~/libs/article-client';
 import { SITE_TITLE } from '~/libs/constants';
 import {
@@ -20,8 +25,10 @@ export default async function Page({
 }) {
   const slug = (await params).slug;
   const [y, m, d, t] = slug;
-  const md = await readArticleFile(`${y}-${m}-${d}_${t}.md`);
+  const fileName = `${y}-${m}-${d}_${t}.md`;
+  const md = await readArticleFile(fileName);
   const frontmatter = parseFrontmatter(md);
+  const { older, newer } = await getAdjacentArticles(fileName);
 
   const meta: ArticleMetaData = {
     tags: frontmatter.tags,
@@ -43,6 +50,7 @@ export default async function Page({
         <TwitterWidget />
       </div>
       <SocialShare url={`${APP_ORIGIN}/${y}/${m}/${d}/${t}/`} />
+      <ArticleNav older={older} newer={newer} />
     </div>
   );
 }

--- a/src/components/ArticleNav.tsx
+++ b/src/components/ArticleNav.tsx
@@ -1,0 +1,53 @@
+import { ArrowLeftIcon, ArrowRightIcon } from '@primer/octicons-react';
+import Link from 'next/link';
+import { SideMenuArticleListItem } from '~/types';
+
+export default function ArticleNav({
+  older,
+  newer,
+}: {
+  older: SideMenuArticleListItem | null;
+  newer: SideMenuArticleListItem | null;
+}) {
+  if (!older && !newer) {
+    return null;
+  }
+
+  return (
+    <nav
+      aria-label="Article navigation"
+      className="grid grid-cols-1 sm:grid-cols-2 gap-2 py-6 border-t border-gray-200"
+    >
+      {older && (
+        <Link
+          href={older.path}
+          rel="prev"
+          className="btn btn-ghost h-auto min-h-0 py-3 justify-start text-left"
+        >
+          <ArrowLeftIcon className="shrink-0" aria-hidden="true" />
+          <span className="flex flex-col items-start gap-1">
+            <span className="text-xs opacity-70 uppercase tracking-wide">
+              Older post
+            </span>
+            <span className="line-clamp-2 font-normal">{older.title}</span>
+          </span>
+        </Link>
+      )}
+      {newer && (
+        <Link
+          href={newer.path}
+          rel="next"
+          className="btn btn-ghost h-auto min-h-0 py-3 justify-end text-right sm:col-start-2"
+        >
+          <span className="flex flex-col items-end gap-1">
+            <span className="text-xs opacity-70 uppercase tracking-wide">
+              Newer post
+            </span>
+            <span className="line-clamp-2 font-normal">{newer.title}</span>
+          </span>
+          <ArrowRightIcon className="shrink-0" aria-hidden="true" />
+        </Link>
+      )}
+    </nav>
+  );
+}

--- a/src/libs/article.ts
+++ b/src/libs/article.ts
@@ -107,6 +107,39 @@ export async function generateRecentPosts(
   return ret;
 }
 
+export type AdjacentArticles = {
+  older: SideMenuArticleListItem | null;
+  newer: SideMenuArticleListItem | null;
+};
+
+async function toNavItem(
+  fileName: string | undefined,
+): Promise<SideMenuArticleListItem | null> {
+  if (!fileName) {
+    return null;
+  }
+  const md = await readArticleFile(fileName);
+  const frontmatter = parseFrontmatter(md);
+  return {
+    title: frontmatter.title,
+    path: generateArticlePath(fileName),
+  };
+}
+
+export async function getAdjacentArticles(
+  fileName: string,
+): Promise<AdjacentArticles> {
+  const fileNames = await getArticleFileNames();
+  const index = fileNames.indexOf(fileName);
+  if (index === -1) {
+    return { older: null, newer: null };
+  }
+  return {
+    newer: await toNavItem(fileNames[index - 1]),
+    older: await toNavItem(fileNames[index + 1]),
+  };
+}
+
 // Read article file. return markdown string
 export function readArticleFile(fileName: string): Promise<string> {
   const articlePath = path.join(process.cwd(), 'src', 'articles', fileName);


### PR DESCRIPTION
## Summary

各記事ページの末尾に、前後の記事（older / newer）へ遷移するナビゲーションリンクを追加します。

- `src/libs/article.ts`: `getAdjacentArticles(fileName)` を追加。日付降順ソート済みの記事一覧から隣接記事のタイトルとパスを解決
- `src/components/ArticleNav.tsx`（新規）: older を左（←）、newer を右（→）に配置する Server Component。daisyUI `btn btn-ghost` + Tailwind grid、モバイルでは縦積み。`rel="prev"` / `rel="next"` 付与
- `src/app/[...slug]/page.tsx`: `SocialShare` の直後に `ArticleNav` を配置

前後記事の算出はすべてビルド時に完結し、リンク先は `generateStaticParams` と同一の記事リストから算出しているため、静的エクスポート（`output: 'export'`, `dynamicParams = false`）でもリンク切れは発生しません。

## Test plan

- [x] `npm run lint` 通過
- [x] `npm run build`（静的エクスポート）成功
- [x] 生成 HTML を静的ファイルサーバーで配信して確認:
  - 中間記事: 両方向のリンクが正しいパス（trailing slash 付き）で出力
  - 最古記事（2016-06-05）: Newer のみ表示
  - 最新記事（2026-06-30）: Older のみ表示
- [x] デスクトップで左右 2 カラム、375px 幅で縦積みになることをスクリーンショットで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)